### PR TITLE
feat(volunteer): 登録用APIを作成する

### DIFF
--- a/VOLUNet-BE/src/index.ts
+++ b/VOLUNet-BE/src/index.ts
@@ -15,9 +15,11 @@ app.get("/health", (c) => {
 });
 
 interface volunteerPost {
+  category: "EnvironmentProtection" | "Welfare" | "CommunityActivity";
   volunteerName: string;
   location: string;
   eventDate: Date;
+  numPeople: number;
   description: string;
 }
 
@@ -28,11 +30,12 @@ app.post("/volunteer", async (c) => {
 
   try {
     const result = await db.insert(volunteers).values({
-      // TODO: 認可ロジックがいる
-      organizerName: "",
+      organizerName: "TODO(小梶):organizerNameどうするつもりか聞く",
       volunteerName: body.volunteerName,
+      category: body.category,
       location: body.location,
       eventDate: body.eventDate,
+      numPeople: body.numPeople,
       description: body.description,
     });
 

--- a/VOLUNet-BE/src/index.ts
+++ b/VOLUNet-BE/src/index.ts
@@ -1,11 +1,46 @@
 import { Hono } from "hono";
+import { drizzle, DrizzleD1Database } from "drizzle-orm/d1";
+import { users, volunteers } from "./db/schema";
 
-const app = new Hono();
+type Bindings = {
+  DB: DrizzleD1Database;
+};
+
+const app = new Hono<{ Bindings: Bindings }>();
 
 app.get("/health", (c) => {
   return c.json({
     message: "service up",
   });
+});
+
+interface volunteerPost {
+  volunteerName: string;
+  location: string;
+  eventDate: Date;
+  description: string;
+}
+
+// ボランティア登録用API
+app.post("/volunteer", async (c) => {
+  const db = drizzle(c.env.DB);
+  const body = c.req.json() as unknown as volunteerPost;
+
+  try {
+    const result = await db.insert(volunteers).values({
+      // TODO: 認可ロジックがいる
+      organizerName: "",
+      volunteerName: body.volunteerName,
+      location: body.location,
+      eventDate: body.eventDate,
+      description: body.description,
+    });
+
+    return c.json({ message: "ボランティアデータを正常に登録しました。" });
+  } catch (e) {
+    c.status(500);
+    return c.json("ボランティアデータを正常に登録出来ませんでした。");
+  }
 });
 
 export default app;


### PR DESCRIPTION
# 概要
表題の通りです。
# 動作確認手順
`POST:/volunteer`を参照
# 関連 Issue

close https://github.com/VOLUNet/VOLUNet/issues/7