### PR TITLE
feat(volunteer): ボランティアリスト(学生用)取得APIを実装する

### DIFF
--- a/VOLUNet-BE/src/index.ts
+++ b/VOLUNet-BE/src/index.ts
@@ -60,22 +60,43 @@ app.post("/volunteer", async (c) => {
 });
 
 // ボランティアリスト検索API
+// 学生側はquery param に student:true を与える
 app.get("/volunteer-list", async (c) => {
   const db = drizzle(c.env.DB);
+  const studentSideSearchFlag =
+    c.req.query("student") === "true" ? true : false;
 
   try {
-    const results = await db.select().from(volunteers);
+    if (studentSideSearchFlag) {
+      const results = await db
+        .select()
+        .from(volunteers)
+        .where(eq(volunteers.isSharedToStudents, true));
 
-    const response = results.map((result) => ({
-      id: result.id,
-      volunteerName: result.volunteerName,
-      description: result.description,
-      organizationName: result.organizerName,
-      eventDate: result.eventDate,
-      location: result.location,
-    }));
+      const response = results.map((result) => ({
+        id: result.id,
+        volunteerName: result.volunteerName,
+        description: result.description,
+        organizationName: result.organizerName,
+        eventDate: result.eventDate,
+        location: result.location,
+      }));
 
-    return c.json(response);
+      return c.json(response);
+    } else {
+      const results = await db.select().from(volunteers);
+
+      const response = results.map((result) => ({
+        id: result.id,
+        volunteerName: result.volunteerName,
+        description: result.description,
+        organizationName: result.organizerName,
+        eventDate: result.eventDate,
+        location: result.location,
+      }));
+
+      return c.json(response);
+    }
   } catch (e) {
     c.status(500);
     return c.json("ボランティアデータを正常に取得出来ませんでした。");
@@ -144,4 +165,5 @@ app.put("/volunteer/:id", async (c) => {
     });
   }
 });
+
 export default app;


### PR DESCRIPTION
# 概要
表題の通りです。
# 動作確認手順
`GET:/volunteer-list`
# 補足情報
`query param`に対して`student:true`を与えて呼び出す
# 関連 Issue

close #21 
