### PR TITLE
fix: usersテーブルのemailカラム名の重複を修正

### DIFF
--- a/VOLUNet-BE/src/db/schema.ts
+++ b/VOLUNet-BE/src/db/schema.ts
@@ -27,7 +27,7 @@ export const volunteers = sqliteTable("volunteers", {
 export const users = sqliteTable("users", {
   id: integer({ mode: "number" }).primaryKey({ autoIncrement: true }),
   name: text("name").notNull(),
-  email: text("name").notNull(),
+  email: text("email").notNull(),
   iconUrl: text("icon_url").notNull(),
   comment: text("comment").notNull(),
   qrCode: text("qr_code").notNull(),


### PR DESCRIPTION
# 概要
users テーブルの email カラム名が name と重複していたため、正しく修正しました。
# 動作確認手順
git diff main で email: text("email").notNull() のみが差分として存在することを確認済み。
# 補足情報
この修正はスキーマの整合性を保つための軽微な修正です。マイグレーションの適用が別途必要です。
# 関連 Issue

close #45 
