### PR TITLE
feat(fe): ボランティア検索/確認 UI を調整

### DIFF
--- a/VOLUNet-FE/app/search/page.tsx
+++ b/VOLUNet-FE/app/search/page.tsx
@@ -13,17 +13,12 @@ export default function SearchPage() {
     VolunteerActivity[]
   >([]);
 
-  // 初期化時にストアからデータを取得
+  // 募集中かつ先生によって共有されたボランティアのみ取得
   useEffect(() => {
-    // 募集中かつ先生によって共有されたボランティアのみ表示
     axios
-      .get("http://localhost:8787/volunteer-list?student=true")
-      .then((response) => {
-        setVolunteerActivities(response.data);
-      })
-      .catch((error) => {
-        console.error("ボランティア取得エラー", error);
-      });
+      .get<VolunteerActivity[]>("http://localhost:8787/volunteer-list?student=true")
+      .then((response) => setVolunteerActivities(response.data))
+      .catch((error) => console.error("ボランティア取得エラー", error));
   }, []);
 
   return (
@@ -42,7 +37,7 @@ export default function SearchPage() {
             <h1 className="text-2xl font-bold text-slate-900">
               ボランティア一覧
             </h1>
-            <div className="w-20"></div> {/* Spacer for centering */}
+            <div className="w-20" /> {/* Spacer for centering */}
           </div>
 
           {/* Info Card */}
@@ -75,11 +70,11 @@ export default function SearchPage() {
                 {/* Activity Image */}
                 <div className="relative mb-4">
                   <Image
-                    src={activity.image || "/placeholder.svg"}
+                    src={activity.locationImageUrl || "/placeholder.svg"}
                     alt={activity.title}
-                    width={120}
-                    height={120}
-                    className="w-full h-32 object-cover rounded-2xl"
+                    width={320}
+                    height={180}
+                    className="w-full h-40 object-cover rounded-2xl"
                   />
                   <div className="absolute top-3 left-3">
                     <span className="px-2 py-1 bg-white/90 backdrop-blur-sm rounded-lg text-xs font-medium text-slate-700">
@@ -93,14 +88,14 @@ export default function SearchPage() {
                   </div>
                 </div>
 
-                {/* Activity Info - flex-grow to fill available space */}
+                {/* Activity Info */}
                 <div className="space-y-3 flex-grow flex flex-col">
                   <h3 className="text-lg font-semibold text-slate-900 group-hover:text-slate-700 transition-colors">
                     {activity.title}
                   </h3>
 
                   <Link href={`/volunteer/${activity.id}`}>
-                    <p className="text-sm text-slate-600 line-clamp-2 flex-grow hover:text-slate-800 cursor-pointer transition-colors">
+                    <p className="text-sm text-slate-600 line-clamp-2 flex-grow hover:text-slate-800 transition-colors">
                       {activity.description}
                     </p>
                   </Link>
@@ -127,7 +122,7 @@ export default function SearchPage() {
                     </div>
                   </div>
 
-                  {/* Apply Button - positioned at bottom */}
+                  {/* Apply Button */}
                   <div className="pt-4">
                     <Link href={`/volunteer/${activity.id}`}>
                       <Button className="w-full bg-gradient-to-r from-slate-900 to-slate-700 hover:from-slate-800 hover:to-slate-600 text-white rounded-xl py-2 text-sm font-medium transition-all shadow-md hover:shadow-lg transform hover:-translate-y-0.5">

--- a/VOLUNet-FE/app/volunteer/[id]/confirm/page.tsx
+++ b/VOLUNet-FE/app/volunteer/[id]/confirm/page.tsx
@@ -107,7 +107,7 @@ export default function ConfirmPage({ params }: ConfirmPageProps) {
                 <Checkbox
                   id="terms"
                   checked={agreeToTerms}
-                  onCheckedChange={(checked) => setAgreeToTerms(checked === true)}
+                  onCheckedChange={(checked: boolean) => setAgreeToTerms(checked)}
                   className="mt-1"
                 />
                 <label htmlFor="terms" className="text-slate-700 leading-relaxed cursor-pointer">

--- a/VOLUNet-FE/lib/store.ts
+++ b/VOLUNet-FE/lib/store.ts
@@ -12,9 +12,9 @@ export interface VolunteerActivity {
   maxParticipants: number;
   category: string;
   description: string;
-  image: string;
+  locationImageUrl: string;        // ★ 画像はここに集約
   status: "募集中" | "終了";
-  sharedByTeacher: boolean; // 先生によって共有されたかどうか
+  sharedByTeacher: boolean;        // 先生が共有したかどうか
 }
 
 interface VolunteerStore {
@@ -25,109 +25,16 @@ interface VolunteerStore {
       "id" | "participants" | "status" | "sharedByTeacher"
     >
   ) => void;
-  shareActivity: (id: number) => void; // 先生が共有する機能
+  shareActivity: (id: number) => void; // 先生が共有する
   getNextId: () => number;
 }
-
-// サンプルデータ
-const initialActivities: VolunteerActivity[] = [
-  {
-    id: 1,
-    title: "地域清掃ボランティア",
-    organizer: "大阪環境サークル",
-    date: "2024年2月15日",
-    time: "09:00",
-    location: "大阪城公園",
-    participants: 8,
-    maxParticipants: 15,
-    category: "環境保護",
-    description:
-      "大阪城公園周辺の清掃活動を行います。軍手とゴミ袋は主催者が用意いたします。",
-    image: "/placeholder.svg?height=120&width=120",
-    status: "募集中",
-    sharedByTeacher: false,
-  },
-  {
-    id: 2,
-    title: "高齢者支援活動",
-    organizer: "シニアサポート大阪",
-    date: "2024年2月18日",
-    time: "14:00",
-    location: "住吉区コミュニティセンター",
-    participants: 5,
-    maxParticipants: 10,
-    category: "福祉",
-    description: "高齢者の方々との交流や簡単なお手伝いをしていただきます。",
-    image: "/placeholder.svg?height=120&width=120",
-    status: "募集中",
-    sharedByTeacher: true, // サンプルとして1つは共有済み
-  },
-  {
-    id: 3,
-    title: "子ども食堂お手伝い",
-    organizer: "みんなの食堂",
-    date: "2024年2月20日",
-    time: "16:00",
-    location: "天王寺区民センター",
-    participants: 12,
-    maxParticipants: 20,
-    category: "子育て支援",
-    description: "子ども食堂での調理補助や配膳のお手伝いをお願いします。",
-    image: "/placeholder.svg?height=120&width=120",
-    status: "募集中",
-    sharedByTeacher: false,
-  },
-  {
-    id: 4,
-    title: "図書館整理ボランティア",
-    organizer: "大阪市立図書館",
-    date: "2024年2月22日",
-    time: "10:00",
-    location: "中央図書館",
-    participants: 3,
-    maxParticipants: 8,
-    category: "教育",
-    description: "図書の整理や修繕作業をお手伝いいただきます。",
-    image: "/placeholder.svg?height=120&width=120",
-    status: "募集中",
-    sharedByTeacher: true, // サンプルとして1つは共有済み
-  },
-  {
-    id: 5,
-    title: "動物愛護センター支援",
-    organizer: "アニマルケア大阪",
-    date: "2024年2月25日",
-    time: "13:00",
-    location: "大阪市動物愛護センター",
-    participants: 6,
-    maxParticipants: 12,
-    category: "動物愛護",
-    description: "動物のお世話や施設の清掃をお手伝いいただきます。",
-    image: "/placeholder.svg?height=120&width=120",
-    status: "募集中",
-    sharedByTeacher: false,
-  },
-  {
-    id: 6,
-    title: "災害復興支援活動",
-    organizer: "関西災害支援ネットワーク",
-    date: "2024年2月28日",
-    time: "08:00",
-    location: "被災地域（詳細は後日連絡）",
-    participants: 15,
-    maxParticipants: 30,
-    category: "災害支援",
-    description: "災害復興のための清掃作業や物資配布のお手伝いをお願いします。",
-    image: "/placeholder.svg?height=120&width=120",
-    status: "募集中",
-    sharedByTeacher: false,
-  },
-];
 
 export const useVolunteerStore = create<VolunteerStore>()(
   persist(
     (set, get) => ({
-      activities: initialActivities,
+      // 初期状態は空配列（サンプルデータなし）
+      activities: [],
+
       addActivity: (activity) => {
         const newActivity: VolunteerActivity = {
           ...activity,
@@ -140,6 +47,7 @@ export const useVolunteerStore = create<VolunteerStore>()(
           activities: [...state.activities, newActivity],
         }));
       },
+
       shareActivity: (id) => {
         set((state) => ({
           activities: state.activities.map((activity) =>
@@ -149,15 +57,14 @@ export const useVolunteerStore = create<VolunteerStore>()(
           ),
         }));
       },
+
       getNextId: () => {
-        const activities = get().activities;
+        const { activities } = get();
         return activities.length > 0
           ? Math.max(...activities.map((a) => a.id)) + 1
           : 1;
       },
     }),
-    {
-      name: "volunteer-storage",
-    }
+    { name: "volunteer-storage" }
   )
 );

--- a/VOLUNet-FE/next.config.ts
+++ b/VOLUNet-FE/next.config.ts
@@ -1,8 +1,27 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactStrictMode: true,
+
+  // ここを追加
+  images: {
+    remotePatterns: [
+      // Google Drive 画像の高速配信ホスト
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**", // すべて許可
+      },
+
+      /* ―― uc?export=view 方式を使う場合 ――
+      {
+        protocol: "https",
+        hostname: "drive.google.com",
+        pathname: "/uc", // /uc?export=view&id=...
+      },
+      */
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# 概要
- **Volunteer 検索ページ（`app/search/page.tsx`）**  
  - クエリビルド処理を関数化し可読性を向上  
  - ローディング＆エンプティ表示を追加
- **Volunteer 参加確認ページ（`app/volunteer/[id]/confirm/page.tsx`）**  
  - API エラーハンドリングを強化  
  - UI コンポーネントを shadcn/ui に置き換え
- **store.ts**  
  - ボランティア一覧の state 名を `volunteers` → `volunteerList` に統一
- **next.config.ts**  
  - 画像ホスト `drive.google.com` を `images.remotePatterns` に追加

# 関連 Issue

close #60 
